### PR TITLE
Correctly disallow gluing of optic components in item form.

### DIFF
--- a/syrup.lua
+++ b/syrup.lua
@@ -102,7 +102,7 @@ nodecore.register_craft({
 		indexkeys = "group:optic_gluable",
 		duration = 2,
 		nodes = {{
-				match = {groups = {optic_gluable = true}}, stacked = false
+				match = {groups = {optic_gluable = true}, stacked = false}
 		}},
 		after = function(pos, data)
 			data.node.name = data.node.name .. suff


### PR DESCRIPTION
Port from [vanilla patch](https://gitlab.com/sztest/nodecore/-/merge_requests/31).