### PR TITLE
Massively buff lux absorption of reinforced glass.

### DIFF
--- a/reinforced.lua
+++ b/reinforced.lua
@@ -33,7 +33,7 @@ minetest.register_node(modname .. ":glass_hard", {
 		silica = 1,
 		silica_reinforced = 1,
 		cracky = 4,
-		lux_absorb = 20,
+		metallic = 1,
 		scaling_time = 300
 	},
 	sunlight_propagates = true,


### PR DESCRIPTION
(from commit message): "A lux-absorb value of 20 provides 20/64 absorption, or just over 31%. This value is likely much lower than WintersKnight intended, and is in fact less than half as effective as the 83% absorption it would have due to its cracky value if the line was omitted. I've given it the metallic group (100% absorption) as that seems to be the intention."

Radiation logic is [here](https://gitlab.com/sztest/nodecore/-/blob/master/mods/nc_lux/radiation.lua); lines 72-87 are most important in this case. In the future, I would suggest more thorough research, rather than making up a number which feels right. Testing of the rad blocking in-game would also reveal mistakes like this.

...this is all assuming you actually want the glass to be good at blocking rad. If not, hats off for the bamboozlement.