### PR TITLE
Fix bug which rendered eggcorns un-peatable

### DIFF
--- a/popeggcorn.lua
+++ b/popeggcorn.lua
@@ -21,9 +21,8 @@ minetest.register_node(modname .. ":cornplank", {
 })
 ------------------------------------------------------------------------
 -- This allows eggcorns to be used in a cook recipe while still allowing you to 'burn the popcorn'
-minetest.override_item("nc_tree:eggcorn",
-	{groups = {flammable = 20}}
-)
+core.registered_items["nc_tree:eggcorn"].groups.flammable = 20
+
 ------------------------------------------------------------------------
 local function findheat(pos)
 	return nodecore.find_nodes_around(pos, "group:damage_radiant")


### PR DESCRIPTION
Eggcorn flammability is increased from 3 to 20 for the popeggcorn recipe, but the change was being made with override_item, which replaced all eggcorn groups with {flammable = 20} instead of altering the existing group without touching the other groups. Working as intended now.